### PR TITLE
Added config to golangci action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
           go-version: 1.18
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
+        with:
+          args: --config=.golangci.yaml
 
   markdownlint-cli:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Current GitHub Action workflow uses the golangci-lint-action but does not acknowledge the golangci.yml configuration file in the repository root.

Fix: Added args to load YML during action.