### PR TITLE
Add enum.Builder

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 linters:
   disable:
+    - dupword
     - depguard
   presets:
     - bugs

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ var (
 fmt.Println(Red.Value.UI)
 ```
 
+If the enum has lots of members and new ones may be added over time, it's easy to forget to register all members in the enum. To prevent this, use enum.Builder to define an enum:
+
+```go
+type Color enum.Member[string]
+
+var (
+  b      = enum.NewBuilder[string, Color]()
+  Red    = b.Add(Color{"red"})
+  Green  = b.Add(Color{"green"})
+  Blue   = b.Add(Color{"blue"})
+  Colors = b.Enum()
+)
+```
+
 ## 🤔 QnA
 
 1. **What happens when enums are added in Go itself?** I'll keep it alive until someone uses it but I expect the project popularity to quickly die out when there is native language support for enums. When you can mess with the compiler itself, you can do more. For example, this package can't provide an exhaustiveness check for switch statements using enums (maybe only by implementing a linter) but proper language-level enums would most likely have it.

--- a/enum.go
+++ b/enum.go
@@ -129,3 +129,35 @@ func (e Enum[M, V]) GoString() string {
 	joined := strings.Join(values, ", ")
 	return fmt.Sprintf("enum.New(%s)", joined)
 }
+
+// Builder is a constructor for an [Enum].
+//
+// Use [Builder.Add] to add new members to the future enum
+// and then call [Builder.Enum] to create a new [Enum] with all added members.
+//
+// Builder is useful for when you have lots of enum members, and new ones
+// are added over time, as the project grows. In such scenario, it's easy to forget
+// to add in the [Enum] a newly created [Member].
+// The builder is designed to prevent that.
+type Builder[M iMember[V], V comparable] struct {
+	members  []M
+	finished bool
+}
+
+// NewBuilder creates a new [Builder], a constructor for an [Enum].
+func NewBuilder[V comparable, M iMember[V]]() Builder[M, V] {
+	return Builder[M, V]{make([]M, 0), false}
+}
+
+// Add registers a new [Member] in the builder.
+func (b *Builder[M, V]) Add(m M) M {
+	b.members = append(b.members, m)
+	return m
+}
+
+// Enum creates a new [Enum] with all members registered using [Builder.Add].
+func (b *Builder[M, V]) Enum() Enum[M, V] {
+	b.finished = true
+	e := New(b.members...)
+	return e
+}

--- a/enum_test.go
+++ b/enum_test.go
@@ -89,3 +89,16 @@ func TestEnum_Index_Panic(t *testing.T) {
 	}()
 	Colors.Index(Color{"purple"})
 }
+
+func TestBuilder(t *testing.T) {
+	is := is.New(t)
+	type Country enum.Member[string]
+	var (
+		b         = enum.NewBuilder[string, Country]()
+		NL        = b.Add(Country{"Netherlands"})
+		FR        = b.Add(Country{"France"})
+		BE        = b.Add(Country{"Belgium"})
+		Countries = b.Enum()
+	)
+	is.Equal(Countries.Members(), []Country{NL, FR, BE})
+}

--- a/example_test.go
+++ b/example_test.go
@@ -182,3 +182,22 @@ func ExampleEnum_TypeName() {
 	fmt.Println(tname)
 	// Output: string
 }
+
+func ExampleNewBuilder() {
+	type Color enum.Member[string]
+	var (
+		b      = enum.NewBuilder[string, Color]()
+		Red    = b.Add(Color{"red"})
+		Green  = b.Add(Color{"green"})
+		Blue   = b.Add(Color{"blue"})
+		Colors = b.Enum()
+	)
+
+	fmt.Println(
+		Colors.Contains(Red),
+		Colors.Contains(Green),
+		Colors.Contains(Blue),
+	)
+	// Output:
+	// true true true
+}


### PR DESCRIPTION
Add enum.Builder which can be used to construct a new enum:

```go
type Color enum.Member[string]

var (
  b      = enum.NewBuilder[string, Color]()
  Red    = b.Add(Color{"red"})
  Green  = b.Add(Color{"green"})
  Blue   = b.Add(Color{"blue"})
  Colors = b.Enum()
)
```

The goal is to prevent situations when the enum may evolve as the project grows and people might forget to add new members to the enum.

I'll leave the PR open so you folks can leave your comments. Do you find it useful? Do you have ideas on how to make it better?