### PR TITLE
Add Enum.Match

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -138,11 +138,11 @@ var (
 	Books           = enum.New(EfficientGo, ConcurrencyInGo)
 )
 
-func (b BookValue) Match(v BookValue) bool {
+func (b BookValue) Equal(v BookValue) bool {
 	return b.ISBN == v.ISBN
 }
 
-func TestEnum_Match_Book(t *testing.T) {
+func TestParse(t *testing.T) {
 	is := is.New(t)
 	tests := []struct {
 		isbn string
@@ -155,26 +155,7 @@ func TestEnum_Match_Book(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.isbn, func(t *testing.T) {
 			v := BookValue{ISBN: tt.isbn}
-			got := Books.Match(v)
-			is.Equal(got, tt.want)
-		})
-	}
-}
-
-func TestEnum_Match_Color(t *testing.T) {
-	is := is.New(t)
-	tests := []struct {
-		color string
-		want  *Color
-	}{
-		{"red", &Red},
-		{"green", &Green},
-		{"blue", &Blue},
-		{"purple", nil},
-	}
-	for _, tt := range tests {
-		t.Run(tt.color, func(t *testing.T) {
-			got := Colors.Match(tt.color)
+			got := enum.Parse(Books, v)
 			is.Equal(got, tt.want)
 		})
 	}

--- a/enum_test.go
+++ b/enum_test.go
@@ -125,3 +125,57 @@ func TestBuilder(t *testing.T) {
 	)
 	is.Equal(Countries.Members(), []Country{NL, FR, BE})
 }
+
+type BookValue struct {
+	Title string
+	ISBN  string
+}
+type Book enum.Member[BookValue]
+
+var (
+	EfficientGo     = Book{BookValue{"Efficient Go", "978-1098105716"}}
+	ConcurrencyInGo = Book{BookValue{"Concurrency in Go", "978-1491941195"}}
+	Books           = enum.New(EfficientGo, ConcurrencyInGo)
+)
+
+func (b BookValue) Match(v BookValue) bool {
+	return b.ISBN == v.ISBN
+}
+
+func TestEnum_Match_Book(t *testing.T) {
+	is := is.New(t)
+	tests := []struct {
+		isbn string
+		want *Book
+	}{
+		{"978-1098105716", &EfficientGo},
+		{"978-1491941195", &ConcurrencyInGo},
+		{"invalid-isbn", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.isbn, func(t *testing.T) {
+			v := BookValue{ISBN: tt.isbn}
+			got := Books.Match(v)
+			is.Equal(got, tt.want)
+		})
+	}
+}
+
+func TestEnum_Match_Color(t *testing.T) {
+	is := is.New(t)
+	tests := []struct {
+		color string
+		want  *Color
+	}{
+		{"red", &Red},
+		{"green", &Green},
+		{"blue", &Blue},
+		{"purple", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.color, func(t *testing.T) {
+			got := Colors.Match(tt.color)
+			is.Equal(got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Add Matcher interface and Match method to Enum for custom matching logic.
This is especially beneficial when the value type is struct, which means that be able to implement a custom matcher.