### PR TITLE
[Feature] enable the implementation of the database/sql/driver.Valuer interface or derived enum.Member types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ Type safe enums for Go without code generation or reflection.
 ## 📦 Installation
 
 ```bash
-go get github.com/orsinium-labs/enum
+go get github.com/orsinium-labs/enum/v2
 ```
+
+## ⛓️‍💥️ Breaking changes compared to v1
+
+- The generic value field of `enum.Member` has been renamed to `Val` from `Value`. 
+  This enables the implementation of the `database/sql/driver.Valuer` interface on derived types.
+
 
 ## 🛠️ Usage
 

--- a/enum.go
+++ b/enum.go
@@ -9,7 +9,7 @@ import (
 
 // Member is an enum member, a specific value bound to a variable.
 type Member[T comparable] struct {
-	Value T
+	Val T
 }
 
 // Equaler check if the two values of the same type are equal.
@@ -27,7 +27,7 @@ type Equaler[V comparable] interface {
 // We also can't use a normal interface because new types
 // don't inherit methods of their base type.
 type iMember[T comparable] interface {
-	~struct{ Value T }
+	~struct{ Val T }
 }
 
 // Enum is a collection of enum members.
@@ -83,7 +83,7 @@ func (e Enum[M, V]) Parse(value V) *M {
 
 // Value returns the wrapped value of the given enum member.
 func (e Enum[M, V]) Value(member M) V {
-	return Member[V](member).Value
+	return Member[V](member).Val
 }
 
 // Index returns the index of the given member in the enum.

--- a/enum_test.go
+++ b/enum_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 
 	"github.com/matryer/is"
-	"github.com/orsinium-labs/enum"
+
+	"github.com/orsinium-labs/enum/v2"
 )
 
 type Color enum.Member[string]
@@ -18,11 +19,11 @@ var (
 
 func TestMember_Value(t *testing.T) {
 	is := is.New(t)
-	is.Equal(Red.Value, "red")
-	is.Equal(Green.Value, "green")
-	is.Equal(Blue.Value, "blue")
-	is.Equal(enum.Member[string]{"blue"}.Value, "blue")
-	is.Equal(enum.Member[int]{14}.Value, 14)
+	is.Equal(Red.Val, "red")
+	is.Equal(Green.Val, "green")
+	is.Equal(Blue.Val, "blue")
+	is.Equal(enum.Member[string]{"blue"}.Val, "blue")
+	is.Equal(enum.Member[int]{14}.Val, 14)
 }
 
 func TestEnum_Parse(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/orsinium-labs/enum"
+	"github.com/orsinium-labs/enum/v2"
 )
 
 func ExampleNew() {
@@ -61,7 +61,7 @@ func ExampleEnum_Parse() {
 
 	parsed := Colors.Parse("red")
 	fmt.Printf("%#v\n", parsed)
-	// Output: &enum_test.Color{Value:"red"}
+	// Output: &enum_test.Color{Val:"red"}
 }
 
 func ExampleEnum_Contains() {
@@ -224,5 +224,5 @@ func ExampleParse() {
 
 	parsed := enum.Parse(Colors, "RED")
 	fmt.Printf("%#v\n", parsed)
-	// Output: &enum_test.Color{Value:"red"}
+	// Output: &enum_test.Color{Val:"red"}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/orsinium-labs/enum
+module github.com/orsinium-labs/enum/v2
 
 go 1.20
 


### PR DESCRIPTION
Hey guys, awesome work, I love this package. But I stumbled over this issue. Since `enum.Member`  holds a field called `Value`, all derived types cannot implement the `database/sql/driver.Valuer` interface due to the naming conflict.

To enable this, I simply renamed the field to `Val`. As this is a breaking change, I declared this as `v2` of this package.

Let me know what you think of this.