### PR TITLE
builder: Less repetitive 'b.AddValue' + strict mode

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -147,11 +147,11 @@ func TestStrictBuilder(t *testing.T) {
 		}
 	}()
 
-	type Country enum.Member[string]
+	type SomeType enum.Member[int]
 	var (
-		b = enum.NewStrictBuilder[string, Country]()
-		_ = b.AddValue("Netherlands")
-		_ = b.AddValue("Netherlands")
+		b = enum.NewStrictBuilder[int, SomeType]()
+		_ = b.AddValue(1)
+		_ = b.AddValue(1)
 		_ = b.Enum()
 	)
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -126,6 +126,38 @@ func TestBuilder(t *testing.T) {
 	is.Equal(Countries.Members(), []Country{NL, FR, BE})
 }
 
+func TestBuilderValue(t *testing.T) {
+	is := is.New(t)
+	type Country enum.Member[string]
+	var (
+		b         = enum.NewBuilder[string, Country]()
+		NL        = b.AddValue("Netherlands")
+		FR        = b.AddValue("France")
+		BE        = b.AddValue("Belgium")
+		Countries = b.Enum()
+	)
+	is.Equal(Countries.Members(), []Country{NL, FR, BE})
+}
+
+func TestStrictBuilder(t *testing.T) {
+	// Recover from expected panic
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+	}()
+
+	type Country enum.Member[string]
+	var (
+		b = enum.NewStrictBuilder[string, Country]()
+		_ = b.AddValue("Netherlands")
+		_ = b.AddValue("Netherlands")
+		_ = b.Enum()
+	)
+
+	t.Fatal("expected panic with strict builder")
+}
+
 type BookValue struct {
 	Title string
 	ISBN  string


### PR DESCRIPTION
# Summary

Firstly, thanks for publishing this package. I enjoy using it quite a bit. :)

This change addresses a couple pain points I've ran into:

1. Unnecessary boilerplate when using `enum.Builder` that can be eliminated with existing type inference
2. Someone (usually me) forgetting to change the value when adding a new member.

Both changes added in a backward-compatible way:

```go
// Example using both
type SomeType enum.Member[int]
var (
	b = enum.NewStrictBuilder[int, SomeType]()
	_ = b.AddValue(1)
	_ = b.AddValue(1)
	_ = b.Enum() // panics here due to 'strict'
)
```

# Test Plan

Added two new test cases:

```
> go test -count=1 -race ./...
ok      github.com/orsinium-labs/enum   1.548s
```